### PR TITLE
Fix nim version dependency.

### DIFF
--- a/jsony.nimble
+++ b/jsony.nimble
@@ -5,4 +5,4 @@ license     = "MIT"
 
 srcDir = "src"
 
-requires "nim >= 1.2.2"
+requires "nim >= 1.4.0"


### PR DESCRIPTION
Seems jsony depends on SomeSet to be defined, which was introduced during the nim 1.2.12 -> 1.4.0 transition.