### PR TITLE
Add hooks for set type

### DIFF
--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -14,7 +14,7 @@ proc parseHook*[T](s: string, i: var int, v: var seq[T])
 proc parseHook*[T: enum](s: string, i: var int, v: var T)
 proc parseHook*[T: object|ref object](s: string, i: var int, v: var T)
 proc parseHook*[T](s: string, i: var int, v: var SomeTable[string, T])
-proc parseHook*[T](s: string, i: var int, v: var SomeSet[T])
+proc parseHook*[T](s: string, i: var int, v: var (SomeSet[T]|set[T]))
 proc parseHook*[T: tuple](s: string, i: var int, v: var T)
 proc parseHook*[T: array](s: string, i: var int, v: var T)
 proc parseHook*[T: not object](s: string, i: var int, v: var ref T)
@@ -450,8 +450,8 @@ proc parseHook*[T](s: string, i: var int, v: var SomeTable[string, T]) =
       break
   eatChar(s, i, '}')
 
-proc parseHook*[T](s: string, i: var int, v: var SomeSet[T]) =
-  ## Parse HashSet.
+proc parseHook*[T](s: string, i: var int, v: var (SomeSet[T]|set[T])) =
+  ## Parse HashSet or set type.
   eatSpace(s, i)
   eatChar(s, i, '[')
   while true:
@@ -756,7 +756,7 @@ proc dumpHook*(s: var string, v: ref) =
   else:
     s.dumpHook(v[])
 
-proc dumpHook*[T](s: var string, v: HashSet[T]|OrderedSet[T]) =
+proc dumpHook*[T](s: var string, v: HashSet[T]|OrderedSet[T]|set[T]) =
   s.add '['
   var i = 0
   for e in v:

--- a/tests/test_set.nim
+++ b/tests/test_set.nim
@@ -1,0 +1,101 @@
+import jsony
+
+#set[int8], set[int16]
+block:
+  let
+    s1: set[int8] = {1'i8, 2, 3}
+    s2: set[int16] = {1'i16, 2, 3}
+
+  doAssert s1.toJson() == "[1,2,3]"
+  doAssert s2.toJson() == "[1,2,3]"
+
+  doAssert s1.toJson.fromJson(set[int8]) == s1
+  doAssert s2.toJson.fromJson(set[int16]) == s2
+
+#set[uint8], set[uint16]
+block:
+  let
+    s1: set[uint8] = {1'u8, 2, 3}
+    s2: set[uint16] = {1'u16, 2, 3}
+
+  doAssert s1.toJson() == "[1,2,3]"
+  doAssert s2.toJson() == "[1,2,3]"
+
+  doAssert s1.toJson.fromJson(set[uint8]) == s1
+  doAssert s2.toJson.fromJson(set[uint16]) == s2
+
+#set[char]
+block:
+  let
+    s1: set[char] = {'0'..'9'}
+
+  doAssert s1.toJson() == """["0","1","2","3","4","5","6","7","8","9"]"""
+
+  doAssert s1.toJson.fromJson(set[char]) == s1
+
+#set[enum]
+block:
+  type
+    E1 = enum
+      e1Elem1, e1Elem2, e1Elem3
+    E2 = enum
+      e2Elem1 = "custString1", e2Elem2 = "custString2", e2Elem3 = "custString3"
+    E3 = enum
+      e3Elem1 = 10, e3Elem2 = 20, e3Elem3 = 30
+
+  let
+    s1: set[E1] = {e1Elem1, e1Elem2, e1Elem3}
+    s2: set[E2] = {e2Elem1, e2Elem2, e2Elem3}
+    s3: set[E3] = {e3Elem1, e3Elem2, e3Elem3}
+
+  doAssert s1.toJson() == """["e1Elem1","e1Elem2","e1Elem3"]"""
+  doAssert s2.toJson() == """["custString1","custString2","custString3"]"""
+  doAssert s3.toJson() == """["e3Elem1","e3Elem2","e3Elem3"]"""
+
+  doAssert s1.toJson.fromJson(set[E1]) == s1
+  doAssert s2.toJson.fromJson(set[E2]) == s2
+  doAssert s3.toJson.fromJson(set[E3]) == s3
+
+#type set[enum]
+block:
+  type
+    E1 = enum
+      e1Elem1, e1Elem2, e1Elem3
+    S1 = set[E1]
+
+  let
+    s1: S1 = {e1Elem1, e1Elem2, e1Elem3}
+
+  doAssert s1.toJson() == """["e1Elem1","e1Elem2","e1Elem3"]"""
+
+  doAssert s1.toJson.fromJson(set[E1]) == s1
+
+#object with set[enum]
+block:
+  type
+    E1 = enum
+      e1Elem1, e1Elem2, e1Elem3
+    O1 = object
+      e1: set[E1]
+
+  let
+    o1: O1 = O1(e1: {e1Elem1, e1Elem2, e1Elem3})
+
+  doAssert o1.toJson() == """{"e1":["e1Elem1","e1Elem2","e1Elem3"]}"""
+
+  doAssert o1.toJson.fromJson(O1) == o1
+
+#ref object with set[enum]
+block:
+  type
+    E1 = enum
+      e1Elem1, e1Elem2, e1Elem3
+    O1 = ref object
+      e1: set[E1]
+
+  let
+    o1: O1 = O1(e1: {e1Elem1, e1Elem2, e1Elem3})
+
+  doAssert o1.toJson() == """{"e1":["e1Elem1","e1Elem2","e1Elem3"]}"""
+
+  doAssert o1.toJson.fromJson(O1)[] == o1[]


### PR DESCRIPTION
It's a simple change - I've reused HashSet procs.

During testing I've found a bug with `from jsony import nil` https://github.com/konradmb/jsony/commit/fd08c4e7f9f69c00ba6b1b125ac6f05fcef603b8#diff-2d91982de276dc64eab6f65f18f163e2e279c6e977abb09c0511c7694312f868R73

But you can ignore it for now as it's not connected to this change.