### PR TITLE
Remove re-definition of `SomeSet`

### DIFF
--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -11,13 +11,11 @@ type
   SomeTable*[K, V] = Table[K, V] | OrderedTable[K, V] |
     TableRef[K, V] | OrderedTableRef[K, V]
 
-  SomeSet*[A] = HashSet[A] | OrderedSet[A] | set[A]
-
 proc parseHook*[T](s: string, i: var int, v: var seq[T])
 proc parseHook*[T: enum](s: string, i: var int, v: var T)
 proc parseHook*[T: object|ref object](s: string, i: var int, v: var T)
 proc parseHook*[T](s: string, i: var int, v: var SomeTable[string, T])
-proc parseHook*[T](s: string, i: var int, v: var SomeSet[T])
+proc parseHook*[T](s: string, i: var int, v: var (SomeSet[T]|set[T]))
 proc parseHook*[T: tuple](s: string, i: var int, v: var T)
 proc parseHook*[T: array](s: string, i: var int, v: var T)
 proc parseHook*[T: not object](s: string, i: var int, v: var ref T)
@@ -453,8 +451,8 @@ proc parseHook*[T](s: string, i: var int, v: var SomeTable[string, T]) =
       break
   eatChar(s, i, '}')
 
-proc parseHook*[T](s: string, i: var int, v: var SomeSet[T]) =
-  ## Parse a set type.
+proc parseHook*[T](s: string, i: var int, v: var (SomeSet[T]|set[T])) =
+  ## Parses `HashSet`, `OrderedSet`, or a built-in `set` type.
   eatSpace(s, i)
   eatChar(s, i, '[')
   while true:
@@ -757,7 +755,7 @@ proc dumpHook*(s: var string, v: ref) =
   else:
     s.dumpHook(v[])
 
-proc dumpHook*[T](s: var string, v: SomeSet[T]) =
+proc dumpHook*[T](s: var string, v: SomeSet[T]|set[T]) =
   s.add '['
   var i = 0
   for e in v:


### PR DESCRIPTION
Commit ebee42e04b13 ("A little cleanup around set types.", 2021-10-01)
added an exported definition of `SomeSet` that included the
built-in `set` type.

However, a typical Nim user is familiar with the definition of `SomeSet`
in the standard library of

```Nim
SomeSet*[A] = HashSet[A] | OrderedSet[A]
```

and was thus likely to read the lines

```Nim
proc parseHook*[T](s: string, i: var int, v: var SomeSet[T]) =
```

and
```Nim
proc dumpHook*[T](s: var string, v: SomeSet[T]) =
```

and believe that jsony does not support the built-in `set` type.

This commit therefore removes the `SomeSet` re-definition, which also
means that jsony once again works with code like

```Nim
import std/sets
import pkg/jsony

proc foo[T](s: SomeSet[T]) =
  discard
```

which successfully compiled with jsony 1.0.5 and earlier, but produced
an error with jsony 1.1.0 (2021-11-04):

```
    /tmp/foo.nim(4, 16) Error: ambiguous identifier: 'SomeSet' -- use one of the following:
      sets.SomeSet: SomeSet
      jsony.SomeSet: SomeSet
```

Support for the built-in `set` type was originally added by
commit 9a4f118ac677 (2021-10-01).

Fixes: #33