### PR TITLE
Added more elaborate explanation around dumpHook

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ Gives us:
 ### `proc dumpHook*()` Can be used to serializer into custom representation.
 
 Just like reading custom data types you can also write data types with `dumpHook*()`.
+The `dumpHook()` will receive the incomplete string representation of a given serialization (here `s`).
+You will need to add the serialization of your data type (here `v`) to that string.
 
 ```nim
 type Fraction = object


### PR DESCRIPTION
I ran face first into this issue of not understanding what `s` in the example dump-hook was.
In my naivity I *replaced* the contents of `s` with the serialization-string of my custom datatype, which of course dropped serialization data.

To avoid others from running into the same issue and foster a slightly better understanding of what happens in dumpHooks I added two sentences to the Readme elaborating what `s` is (the currently unfinished serialization string of a given serialization) and how that needs to be appended to.