### PR TITLE
Fix seq[tuple] with named tuples

### DIFF
--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -354,6 +354,9 @@ proc parseObject[T](s: string, i: var int, v: var T) =
       inc i
     else:
       break
+  when compiles(postHook(v)):
+    postHook(v)
+  eatChar(s, i, '}')
 
 proc parseHook*[T: tuple](s: string, i: var int, v: var T) =
   eatSpace(s, i)

--- a/tests/test_tuples.nim
+++ b/tests/test_tuples.nim
@@ -46,4 +46,27 @@ block:
   doAssert v[2] == 13.5
   doAssert v.id == 134
   doAssert v.name == "red"
+
+block:
+  type Entry = tuple[id: int, name: string, dist: float32]
+  var s = """[{"id": 134, "name": "red", "dist": 13.5}]""" 
+  var entries = s.fromJson(seq[Entry])
+  doAssert entries.len == 1
+  var v = entries[0]
+  doAssert v.dist == 13.5 
+  doAssert v[0] == 134
+  doAssert v[1] == "red"
+  doAssert v[2] == 13.5
+  doAssert v.id == 134
+  doAssert v.name == "red"
   doAssert v.dist == 13.5
+  
+type EntryForHook = tuple[id: int, name: string]
+proc postHook(entry: var EntryForHook) =
+  entry.id = 42
+  
+block:
+  var s = """{"id": 6, "name": "red"}"""
+  var v = s.fromJson(EntryForHook)
+  doAssert v.id == 42
+  doAssert v.name == "red"


### PR DESCRIPTION
This currently fails
```nim
import jsony

let json = """[{"name": "John"}]"""

echo json.fromJson(seq[tuple[name: string]])
```
with message
```
Error: unhandled exception: Expected ] but got } instead. At offset: 16 [JsonError]
```

Issue was `parseObject` missing a final `eatChar` for the closing brace.
Fixed by copying the final bits of the parseHook for normal objects