### PR TITLE
fix #52: allow enum keys when parsing tables

### DIFF
--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -14,7 +14,7 @@ type
 proc parseHook*[T](s: string, i: var int, v: var seq[T])
 proc parseHook*[T: enum](s: string, i: var int, v: var T)
 proc parseHook*[T: object|ref object](s: string, i: var int, v: var T)
-proc parseHook*[T](s: string, i: var int, v: var SomeTable[string, T])
+proc parseHook*[K, V](s: string, i: var int, v: var SomeTable[K, V])
 proc parseHook*[T](s: string, i: var int, v: var (SomeSet[T]|set[T]))
 proc parseHook*[T: tuple](s: string, i: var int, v: var T)
 proc parseHook*[T: array](s: string, i: var int, v: var T)
@@ -455,7 +455,7 @@ proc parseHook*[T](s: string, i: var int, v: var Option[T]) =
   parseHook(s, i, e)
   v = some(e)
 
-proc parseHook*[T](s: string, i: var int, v: var SomeTable[string, T]) =
+proc parseHook*[K, V](s: string, i: var int, v: var SomeTable[K, V]) =
   ## Parse an object.
   when compiles(new(v)):
     new(v)
@@ -464,10 +464,10 @@ proc parseHook*[T](s: string, i: var int, v: var SomeTable[string, T]) =
     eatSpace(s, i)
     if i < s.len and s[i] == '}':
       break
-    var key: string
+    var key: K
     parseHook(s, i, key)
     eatChar(s, i, ':')
-    var element: T
+    var element: V
     parseHook(s, i, element)
     v[key] = element
     if i < s.len and s[i] == ',':

--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -712,6 +712,10 @@ template dumpKey(s: var string, v: string) =
   const v2 = v.toJson() & ":"
   s.add v2
 
+template dumpKey(s: var string, v: enum) =
+  const v2 = '"' & $v & '"' & ":"
+  s.add v2
+
 proc dumpHook*(s: var string, v: char) =
   s.add '"'
   s.add v
@@ -762,7 +766,7 @@ proc dumpHook*(s: var string, v: object) =
     for k, e in v.pairs:
       if i > 0:
         s.add ','
-      s.dumpHook(k)
+      s.dumpKey(k)
       s.add ':'
       s.dumpHook(e)
       inc i

--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -712,10 +712,6 @@ template dumpKey(s: var string, v: string) =
   const v2 = v.toJson() & ":"
   s.add v2
 
-template dumpKey(s: var string, v: enum) =
-  const v2 = '"' & $v & '"' & ":"
-  s.add v2
-
 proc dumpHook*(s: var string, v: char) =
   s.add '"'
   s.add v
@@ -766,7 +762,7 @@ proc dumpHook*(s: var string, v: object) =
     for k, e in v.pairs:
       if i > 0:
         s.add ','
-      s.dumpKey(k)
+      s.dumpHook(k)
       s.add ':'
       s.dumpHook(e)
       inc i

--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -14,7 +14,7 @@ type
 proc parseHook*[T](s: string, i: var int, v: var seq[T])
 proc parseHook*[T: enum](s: string, i: var int, v: var T)
 proc parseHook*[T: object|ref object](s: string, i: var int, v: var T)
-proc parseHook*[K, V](s: string, i: var int, v: var SomeTable[K, V])
+proc parseHook*[K: string | enum, V](s: string, i: var int, v: var SomeTable[K, V])
 proc parseHook*[T](s: string, i: var int, v: var (SomeSet[T]|set[T]))
 proc parseHook*[T: tuple](s: string, i: var int, v: var T)
 proc parseHook*[T: array](s: string, i: var int, v: var T)
@@ -455,7 +455,7 @@ proc parseHook*[T](s: string, i: var int, v: var Option[T]) =
   parseHook(s, i, e)
   v = some(e)
 
-proc parseHook*[K, V](s: string, i: var int, v: var SomeTable[K, V]) =
+proc parseHook*[K: string | enum, V](s: string, i: var int, v: var SomeTable[K, V]) =
   ## Parse an object.
   when compiles(new(v)):
     new(v)

--- a/tests/test_tables.nim
+++ b/tests/test_tables.nim
@@ -58,12 +58,6 @@ block:
   doAssert [{"j":"a"}].toJson() ==
     """[{"j":"a"}]"""
 
-block:
-  var s = """{1:"a"}"""
-  var v = s.fromJson(Table[int, string])
-  doAssert v.len == 1
-  doAssert v[1] == "a"
-
 block: # issue 52
   type Answer {.pure.} = enum
     A, B, C

--- a/tests/test_tables.nim
+++ b/tests/test_tables.nim
@@ -57,3 +57,16 @@ block:
 
   doAssert [{"j":"a"}].toJson() ==
     """[{"j":"a"}]"""
+
+block:
+  var s = """{1:"a"}"""
+  var v = s.fromJson(Table[int, string])
+  doAssert v.len == 1
+  doAssert v[1] == "a"
+
+block: # issue 52
+  type Answer {.pure.} = enum
+    A, B, C
+  let a = {Answer.A: "aaaa", Answer.B: "bbb"}.toTable
+  doAssert $(a.toJson().fromJson(Table[Answer, string])) ==
+    """{A: "aaaa", B: "bbb"}"""

--- a/tests/test_tables.nim
+++ b/tests/test_tables.nim
@@ -59,6 +59,18 @@ block:
     """[{"j":"a"}]"""
 
 block: # issue 52
+  type Color = enum
+    Red = "red", Green = "green", Blue = "blue"
+  let s = """{
+    "red": 1,
+    "blue": 2 
+  }"""
+  var v = s.fromJson(Table[Color, int])
+  doAssert v.len == 2
+  doAssert v[Red] == 1
+  doAssert v[Blue] == 2
+
+block: # issue 52
   type Answer {.pure.} = enum
     A, B, C
   let a = {Answer.A: "aaaa", Answer.B: "bbb"}.toTable

--- a/tests/test_tables.nim
+++ b/tests/test_tables.nim
@@ -75,4 +75,4 @@ block: # issue 52
     A, B, C
   let a = {Answer.A: "aaaa", Answer.B: "bbb"}.toTable
   doAssert $(a.toJson().fromJson(Table[Answer, string])) ==
-    """{A: "aaaa", B: "bbb"}"""
+    """{"A": "aaaa", "B": "bbb"}"""

--- a/tests/test_tables.nim
+++ b/tests/test_tables.nim
@@ -65,7 +65,7 @@ block: # issue 52
     "red": 1,
     "blue": 3
   }"""
-  var v = s.fromJson(Table[Color, int])
+  let v = s.fromJson(Table[Color, int])
   doAssert v.len == 2
   doAssert v[Red] == 1
   doAssert v[Blue] == 3
@@ -75,5 +75,5 @@ block: # issue 52
     A, B, C
   let a = {A: "aaaa", B: "bbb"}.toTable
   doAssert $(a.toJson()) == """{"A":"aaaa","B":"bbb"}"""
-  doAssert $(a.toJson().fromJson(Table[Answer, string])) ==
-    """{A: "aaaa", B: "bbb"}"""
+  let t = a.toJson().fromJson(Table[Answer, string])
+  doAssert t == a

--- a/tests/test_tables.nim
+++ b/tests/test_tables.nim
@@ -73,6 +73,7 @@ block: # issue 52
 block: # issue 52
   type Answer {.pure.} = enum
     A, B, C
-  let a = {Answer.A: "aaaa", Answer.B: "bbb"}.toTable
+  let a = {A: "aaaa", B: "bbb"}.toTable
+  doAssert $(a.toJson()) == """{"A":"aaaa","B":"bbb"}"""
   doAssert $(a.toJson().fromJson(Table[Answer, string])) ==
-    """{"A": "aaaa", "B": "bbb"}"""
+    """{A: "aaaa", B: "bbb"}"""


### PR DESCRIPTION
currently jsony can only parse Table with string keys but ~I do not see any problem to allow a generic key~ enum should be fine too. this fixes #52. added two test case for enum, the second of which replicates issue #52 (enum key). **edited** to remove possibility of generic keys.