### PR TITLE
fix #50: add skipHook to skip fields of object when serializing

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,33 @@ Gives us:
 "10/13"
 ```
 
+### `proc skipHook*()` Can be used to skip fields when serializing an object
+
+If you want to skip some fields when serializing an object you can declare a `skipHook*()`
+
+```nim
+type
+  Conn = object
+    id: int
+  Foo = object
+    a: int
+    password: string
+    b: float
+    conn: Conn
+
+proc skipHook*(T: typedesc[Foo], key: static string): bool =
+  key in ["password", "conn"]
+
+var v = Foo(a:1, password: "12345", b:0.5, conn: Conn(id: 1))
+let s = v.toJson()
+```
+
+Gives us:
+
+```
+"{"a":1,"b":0.5}"
+```
+
 ## Static writing with `toStaticJson`.
 
 Sometimes you have some json, and you want to write it in a static way. There is a special function for that:

--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -770,7 +770,7 @@ proc dumpHook*(s: var string, v: object) =
     # Normal objects.
     for k, e in v.fieldPairs:
       when compiles(skipHook(type(v), k)):
-        if skipHook(type(v), k):
+        when skipHook(type(v), k):
           discard
         else:
           if i > 0:

--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -769,11 +769,21 @@ proc dumpHook*(s: var string, v: object) =
   else:
     # Normal objects.
     for k, e in v.fieldPairs:
-      if i > 0:
-        s.add ','
-      s.dumpKey(k)
-      s.dumpHook(e)
-      inc i
+      when compiles(skipHook(type(v), k)):
+        if skipHook(type(v), k):
+          discard
+        else:
+          if i > 0:
+            s.add ','
+          s.dumpKey(k)
+          s.dumpHook(e)
+          inc i
+      else:
+        if i > 0:
+          s.add ','
+        s.dumpKey(k)
+        s.dumpHook(e)
+        inc i
   s.add '}'
 
 proc dumpHook*[N, T](s: var string, v: array[N, t[T]]) =

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -18,5 +18,6 @@ import test_tables
 import test_tojson
 import test_tuples
 import test_refs
+import test_skipHook
 
 echo "all tests pass"

--- a/tests/test_skipHook.nim
+++ b/tests/test_skipHook.nim
@@ -1,0 +1,17 @@
+import jsony
+
+type
+  Conn = object
+    id: int
+  Foo = object
+    a: int
+    password: string
+    b: float
+    conn: Conn
+
+proc skipHook(T: typedesc[Foo], key: static string): bool =
+  key in ["password", "conn"]
+
+let v = Foo(a:1, password: "12345", b:0.5, conn: Conn(id: 1))
+doAssert v.toJson() ==
+  """{"a":1,"b":0.5}"""

--- a/tests/test_skipHook.nim
+++ b/tests/test_skipHook.nim
@@ -12,6 +12,6 @@ type
 proc skipHook(T: typedesc[Foo], key: static string): bool =
   key in ["password", "conn"]
 
-let v = Foo(a:1, password: "12345", b:0.5, conn: Conn(id: 1))
+let v = Foo(a:1, password: "12345", b:0.6, conn: Conn(id: 1))
 doAssert v.toJson() ==
-  """{"a":1,"b":0.5}"""
+  """{"a":1,"b":0.6}"""


### PR DESCRIPTION
fix #50 by allowing to declare a skipHook to skip fields. works at compile time.
also added a new test file with a test case and a new hook section in the readme:

### `proc skipHook*()` Can be used to skip fields when serializing an object

If you want to skip some fields when serializing an object you can declare a `skipHook*()`

```nim
type
  Conn = object
    id: int
  Foo = object
    a: int
    password: string
    b: float
    conn: Conn

proc skipHook*(T: typedesc[Foo], key: static string): bool =
  key in ["password", "conn"]

var v = Foo(a:1, password: "12345", b:0.5, conn: Conn(id: 1))
let s = v.toJson()
```

Gives us:

```
"{"a":1,"b":0.5}"
```
