### PR TITLE
Separate error offset from error message

### DIFF
--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -2,6 +2,7 @@ import jsony/objvar, std/json, std/options, std/parseutils, std/sets,
     std/strutils, std/tables, std/typetraits, std/unicode
 
 type JsonError* = object of ValueError
+  offset*: int
 
 const whiteSpace = {' ', '\n', '\t', '\r'}
 
@@ -27,7 +28,9 @@ proc parseHook*[T: distinct](s: string, i: var int, v: var T)
 
 template error(msg: string, i: int) =
   ## Shortcut to raise an exception.
-  raise newException(JsonError, msg & " At offset: " & $i)
+  var e = newException(JsonError, msg)
+  e.offset = i
+  raise e
 
 template eatSpace*(s: string, i: var int) =
   ## Will consume whitespace.


### PR DESCRIPTION
Hi! Thank you for all your work on this library, it is working well for me but I had a problem with exception error messages not giving enough insight.

The person who raised issue #26 wanted the errors to convey more detail about the nature of the error, but in my case I really just needed to get a better idea of _where_ we are in the JSON as I was having difficulty quickly translating "At offset: 357" into something meaningful.

You said in #26 that although better messages would be nice, you do not want to keep any additional state as it would slow down parsing (fair enough)... so the idea of this PR is that if the offset value is separated from the message part of the error, into its own var, it would allow a proc to be written to reconstruct the offset info into a more human-friendly form. A proc something like this;

```nim
import strutils

proc prettyPrintJsonError(json: string, error: ref JsonError) =
  var newlinePreError = 0
  var newlinePostError = json.len - 1

  for i in countdown(error.offset - 1, 0):
    if json[i] == '\n':
      newlinePreError = i
      break

  for i in countup(error.offset, json.len - 1):
    if json[i] == '\n':
      newlinePostError = i
      break

  let indent = spaces(max(0, error.offset - 1 - newlinePreError))

  echo "offset: " & $error.offset
  echo json[0 ..< newlinePostError]
  echo indent & "^"
  echo indent & " " & error.msg
  echo json[newlinePostError ..< json.len]
```

Example usage;
```nim
import jsony
from json import JsonNode

type
  thing = tuple
    item: string
    size: string

  jsonContainer = object
    things: seq[thing]
    raptors: bool
    hello: string
    someObjects: JsonNode


var jsonString = """
{
  "things": [
    {"item": "elephant", "size": "the same as a double-decker bus"},
    {"item": "mouse", "size": "smaller than a double-decker bus"},
    {"item": "bus", "size": "also the same as a double-decker bus""},
    {"item": "guitar", "size": "less than a double-decker bus"},
    {"item": "train", "size": "quite a bit more than a double-decker bus"}
  ],
  "raptors": false,
  "hello": "world",
  "someObjects": {
    "dolphin": {
      "legs": 0,
      "eyes": 2,
      "fish": "thanks"
    },
    "ball": {
      "shape": "roundy",
    }
  }
}
"""


var parsedJson: jsonContainer

try:
  parsedJson = jsonString.fromJson(jsonContainer)
except JsonError as e:
  prettyPrintJsonError(jsonString, e)
```

resulting in an error message like this one;
```
{
  "things": [
    {"item": "elephant", "size": "the same as a double-decker bus"},
    {"item": "mouse", "size": "smaller than a double-decker bus"},
    {"item": "bus", "size": "also the same as a double-decker bus""},
                                                                  ^
                                                                   Expected } but got " instead.

    {"item": "guitar", "size": "less than a double-decker bus"},
    {"item": "train", "size": "quite a bit more than a double-decker bus"}
  ],
  "raptors": false,
  "hello": "world",
  "someObjects": {
    "dolphin": {
      "legs": 0,
      "eyes": 2,
      "fish": "thanks"
    },
    "ball": {
      "shape": "roundy",
    }
  }
}
```

Ah, much better! And without any impact on jsony's parse speed.  What do you think?  Am I overlooking anything important?