### PR TITLE
avoid ambiguous call to toJson() 

### DIFF
--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -736,9 +736,11 @@ proc dumpHook*(s: var string, v: string) =
       s.dumpStrFast(v)
 
 template dumpKey(s: var string, v: string) =
-  const v2 = v.toJson() & ":"
-  s.add v2
-
+  var escaped = newStringOfCap(v.len + 5)
+  dumpHook(escaped, v)
+  escaped.add ":"
+  s.add escaped
+  
 proc dumpHook*(s: var string, v: char) =
   s.add '"'
   s.add v

--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -736,11 +736,9 @@ proc dumpHook*(s: var string, v: string) =
       s.dumpStrFast(v)
 
 template dumpKey(s: var string, v: string) =
-  var escaped = newStringOfCap(v.len + 5)
-  dumpHook(escaped, v)
-  escaped.add ":"
-  s.add escaped
-  
+  const v2 = jsony.toJson(v) & ":"
+  s.add v2
+
 proc dumpHook*(s: var string, v: char) =
   s.add '"'
   s.add v


### PR DESCRIPTION
as it is in a template, toJson call is ambiguous when some other serialization framework is included by other dependencies.