### PR TITLE
Use `v.isNil` instead of `v == nil` when dumping JsonNode

### DIFF
--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -844,7 +844,7 @@ proc dumpHook*[T](s: var string, v: SomeSet[T]|set[T]) =
 
 proc dumpHook*(s: var string, v: JsonNode) =
   ## Dumps a regular json node.
-  if v == nil:
+  if v.isNil:
     s.add "null"
   else:
     case v.kind:


### PR DESCRIPTION
When v is JsonNode, `v == nil` implies `raises: Exception` on devel and `KeyError` on 1.6, while functioning identically to `v.isNil`