### PR TITLE
Fix missing parseHook top declaration for Option

### DIFF
--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -18,6 +18,7 @@ type
 proc parseHook*[T](s: string, i: var int, v: var seq[T])
 proc parseHook*[T: enum](s: string, i: var int, v: var T)
 proc parseHook*[T: object|ref object](s: string, i: var int, v: var T)
+proc parseHook*[T](s: string, i: var int, v: var Option[T])
 proc parseHook*[K: string | enum, V](s: string, i: var int, v: var SomeTable[K, V])
 proc parseHook*[T](s: string, i: var int, v: var (SomeSet[T]|set[T]))
 proc parseHook*[T: tuple](s: string, i: var int, v: var T)


### PR DESCRIPTION
In tests - objects with optional fields are working fine, but in my project I noticed, that in my case optional fields are triggering hooks for objects, but with declaring hook for option on top fixes this problem