### PR TITLE
Add forward declare before `dumpKey` for `toJson` in `jsony.nim`

### DIFF
--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -757,6 +757,8 @@ proc dumpHook*(s: var string, v: string) =
 
   s.add '"'
 
+proc toJson*[T](v: T): string
+
 template dumpKey(s: var string, v: string) =
   const v2 = v.toJson() & ":"
   s.add v2


### PR DESCRIPTION
Fixes #88 with an error about forward declares.