### PR TITLE
Fix deserialization of objects with default field values

### DIFF
--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -599,6 +599,7 @@ proc fromJson*[T](s: string, x: typedesc[T]): T =
   ## * Missing json fields keep their default values.
   ## * `proc newHook(foo: var ...)` Can be used to populate default values.
   var i = 0
+  result = default(T)
   s.parseHook(i, result)
   eatSpace(s, i)
   if i != s.len:

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -8,6 +8,15 @@ block:
   doAssert v.color == ""
 
 block:
+  type Frog = object
+    legs: int = 4
+
+  var s = "{}"
+  var f = s.fromJson(Frog)
+  # Make sure the default value is deserialized correctly.
+  doAssert f.legs == 4
+
+block:
   type Foo2 = ref object
     field: string
     a: string

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -7,14 +7,15 @@ block:
   var v = s.fromJson(Entry1)
   doAssert v.color == ""
 
-block:
-  type Frog = object
-    legs: int = 4
+when NimMajor >= 2: # Default field values are only supported in Nim 2.0+
+  block:
+    type Frog = object
+      legs: int = 4
 
-  var s = "{}"
-  var f = s.fromJson(Frog)
-  # Make sure the default value is deserialized correctly.
-  doAssert f.legs == 4
+    var s = "{}"
+    var f = s.fromJson(Frog)
+    # Make sure the default value is deserialized correctly.
+    doAssert f.legs == 4
 
 block:
   type Foo2 = ref object


### PR DESCRIPTION
Adding `result = default(T)` to `fromJson` makes sure that object field defaults are assigned before the object is deserialized.