### PR TITLE
Add dumpRenameHook

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,28 @@ Gives us:
 "{"a":1,"b":0.5}"
 ```
 
+### `proc dumpRenameHook*()` Can be used to rename fields when serializing.
+
+If you want to rename some fields when serializing, declare `dumpRenameHook*()`
+
+```nim
+type Node = ref object
+  kind: string
+
+proc dumpRenameHook*(v: typedesc[Node], fieldName: var string) =
+  if fieldName == "kind":
+    fieldName = "type"
+
+var node = Node(kind: "root")
+let s = node.toJson()
+```
+
+Gives us:
+
+```
+{"type":"root"}
+```
+
 ## Static writing with `toStaticJson`.
 
 Sometimes you have some json, and you want to write it in a static way. There is a special function for that:

--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -758,9 +758,9 @@ proc dumpHook*(s: var string, v: string) =
 
   s.add '"'
 
-template dumpKey(s: var string, v: string) =
-  const v2 = jsony.toJson(v) & ":"
-  s.add v2
+template dumpKey(s: var string, v: var string) =
+  s.add jsony.toJson(v)
+  s.add ":"
 
 proc dumpHook*(s: var string, v: char) =
   s.add '"'
@@ -819,19 +819,24 @@ proc dumpHook*(s: var string, v: object) =
   else:
     # Normal objects.
     for k, e in v.fieldPairs:
+      var key = k
       when compiles(skipHook(type(v), k)):
         when skipHook(type(v), k):
           discard
         else:
+          when compiles(dumpRenameHook(type(v), key)):
+            dumpRenameHook(type(v), key)
           if i > 0:
             s.add ','
-          s.dumpKey(k)
+          s.dumpKey(key)
           s.dumpHook(e)
           inc i
       else:
+        when compiles(dumpRenameHook(type(v), key)):
+          dumpRenameHook(type(v), key)
         if i > 0:
           s.add ','
-        s.dumpKey(k)
+        s.dumpKey(key)
         s.dumpHook(e)
         inc i
   s.add '}'

--- a/tests/test_dumpRenameHook.nim
+++ b/tests/test_dumpRenameHook.nim
@@ -1,0 +1,16 @@
+import jsony
+
+type
+  Foo = object
+    aVal: int
+    bVal: bool
+
+proc dumpRenameHook(v: typedesc[Foo], fieldName: var string) =
+  if fieldName == "aVal":
+    fieldName = "a_val"
+
+let v = Foo(aVal:2, bVal: true)
+let ser = v.toJson()
+echo $ser
+doAssert ser ==
+  """{"a_val":2,"bVal":true}"""


### PR DESCRIPTION
As `renameHook` is for deserializing, `dumpRenameHook` is for serializing.

It seems like the correct change to achieve what I need, but I'm not sure how changing the `v2` in `dumpKey` from a static string to a variable one will affect performance.

EDITED TO ADD: I'm fine if you reject this PR as I can achieve what I want by writing my own `dumpHook` (I just have to duplicate some object dumping logic).