### PR TITLE
Fix duplicate discriminator field in object variants

### DIFF
--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -480,16 +480,13 @@ proc parseHook*[T: object|ref object](s: string, i: var int, v: var T) =
   when v.isObjectVariant:
     # Object variant, check for duplicate discriminator field.
     # -d:release has different behavior.
-    when defined(release):
-      let discBefore = v.discriminatorField
+    let discBefore = v.discriminatorField
+    try:
       parseObjectInner(s, i, v)
-      if v.discriminatorField != discBefore:
-        error("Duplicate discriminator field.", i)
-    else:
-      try:
-        parseObjectInner(s, i, v)
-      except FieldDefect:
-        error("Duplicate discriminator field.", i)
+    except FieldDefect:
+      error("Duplicate discriminator field.", i)
+    if v.discriminatorField != discBefore:
+      error("Duplicate discriminator field.", i)
   else:
     parseObjectInner(s, i, v)
   eatChar(s, i, '}')

--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -484,12 +484,12 @@ proc parseHook*[T: object|ref object](s: string, i: var int, v: var T) =
       let discBefore = v.discriminatorField
       parseObjectInner(s, i, v)
       if v.discriminatorField != discBefore:
-        error("Duplicate discriminator field with conflicting value.", i)
+        error("Duplicate discriminator field.", i)
     else:
       try:
         parseObjectInner(s, i, v)
       except FieldDefect:
-        error("Duplicate discriminator field with conflicting value.", i)
+        error("Duplicate discriminator field.", i)
   else:
     parseObjectInner(s, i, v)
   eatChar(s, i, '}')

--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -477,7 +477,21 @@ proc parseHook*[T: object|ref object](s: string, i: var int, v: var T) =
           new(v)
         break
     i = saveI
-  parseObjectInner(s, i, v)
+  when v.isObjectVariant:
+    # Object variant, check for duplicate discriminator field.
+    # -d:release has different behavior.
+    when defined(release):
+      let discBefore = v.discriminatorField
+      parseObjectInner(s, i, v)
+      if v.discriminatorField != discBefore:
+        error("Duplicate discriminator field with conflicting value.", i)
+    else:
+      try:
+        parseObjectInner(s, i, v)
+      except FieldDefect:
+        error("Duplicate discriminator field with conflicting value.", i)
+  else:
+    parseObjectInner(s, i, v)
   eatChar(s, i, '}')
 
 proc parseHook*[T](s: string, i: var int, v: var Option[T]) =

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -282,6 +282,29 @@ block:
   doAssert c.kind == nkFloat
   doAssert d.kind == nkInt
 
+
+block:
+  # Duplicate discriminator with a conflicting value raises JsonError.
+  var raised = false
+  try:
+    discard """{"kind":"nkFloat","floatVal":3.14,"kind":"nkInt"}""".fromJson(
+      ValueNode)
+  except JsonError:
+    raised = true
+  doAssert raised,
+    "expected JsonError for conflicting duplicate discriminator"
+
+block:
+  # Same test for ref object variant.
+  var raised = false
+  try:
+    discard """{"kind":"nkFloat","floatVal":3.14,"kind":"nkInt"}""".fromJson(
+      RefNode)
+  except JsonError:
+    raised = true
+  doAssert raised,
+    "expected JsonError for conflicting duplicate discriminator"
+
 # test https://forum.nim-lang.org/t/7619
 
 import jsony


### PR DESCRIPTION
## Summary
- Detect duplicate discriminator fields with conflicting values during JSON parsing of object variants.
- In debug mode, catches Nim's FieldDefect; in release mode, compares the discriminator before and after parsing.
- Both paths raise a clear JsonError instead of silently corrupting the variant.

## Test plan
- Added tests for both ValueNode and RefNode with conflicting duplicate discriminator JSON.