### PR TITLE
Migrate CI to Nimby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,22 +1,25 @@
 name: Github Actions
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        nim-version: ['1.4.0', '1.4.x', '1.6.x', '2.0.x', '2.2.x', 'stable']
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v5
-    - uses: jiro4989/setup-nim-action@v2
-      with:
-        nim-version: ${{ matrix.nim-version }}
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - run: nimble test -y
-    - run: nimble test --gc:orc -y
-    - run: nim js -r tests/all.nim
-    - run: nim cpp -d:release --gc:arc -r tests/all.nim
+      - uses: actions/checkout@v5
+      - uses: treeform/setup-nim-action@v6
+      - name: Install dependencies
+        shell: bash
+        run: |
+          cd ..
+          nimby install -g "${{ github.event.repository.name }}/${{ github.event.repository.name }}.nimble"
+      - run: nim r tests/tests.nim

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,10 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+permissions:
+  contents: write
 env:
-  nim-version: 'stable'
   nim-src: src/${{ github.event.repository.name }}.nim
   deploy-dir: .gh-pages
 jobs:
@@ -12,11 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: jiro4989/setup-nim-action@v2
-        with:
-          nim-version: ${{ env.nim-version }}
-      - run: nimble install -Y
-      - run: nimble doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
+      - uses: treeform/setup-nim-action@v6
+      - name: Install dependencies
+        shell: bash
+        run: |
+          cd ..
+          nimby install -g "${{ github.event.repository.name }}/${{ github.event.repository.name }}.nimble"
+      - run: nim doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
       - name: "Copy to index.html"
         run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html
       - name: Deploy documents

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,0 +1,7 @@
+import test_arrays, test_char, test_distinct, test_enums, test_errors,
+    test_fast_numbers, test_json_in_json, test_numbers, test_objects,
+    test_options, test_parseHook, test_quirkydump, test_rawjson, test_refs,
+    test_sets, test_skip_nil_keys, test_skipHook, test_strings, test_tables,
+    test_tojson, test_tuples
+
+echo "all tests pass"


### PR DESCRIPTION
## What changed

- Migrated the build workflow to `treeform/setup-nim-action@v6` and Nimby dependency installation from the workspace parent.
- Standardized CI to run `nim r tests/tests.nim` on Ubuntu, macOS, and Windows without custom memory-manager or thread flags.
- Migrated the docs workflow to the new setup action, Nimby install pattern, manual dispatch, and the required `nim doc` invocation.
- Added `tests/tests.nim` as the standard test entrypoint.

## Why

This brings jsony onto the new Nim build system and matches the repository GitHub Actions standard.

## Validation

- `cd ..; nimby install -g jsony/jsony.nimble`
- `nim r tests/tests.nim`
- `nim doc --index:on --project --git.url:https://github.com/treeform/jsony --git.commit:master --out:.gh-pages src/jsony.nim`