### PR TITLE
fix: Forward declare the Option parseHook

### DIFF
--- a/src/jsony.nim
+++ b/src/jsony.nim
@@ -26,6 +26,7 @@ proc parseHook*[T: not object](s: string, i: var int, v: var ref T)
 proc parseHook*(s: string, i: var int, v: var JsonNode)
 proc parseHook*(s: string, i: var int, v: var char)
 proc parseHook*[T: distinct](s: string, i: var int, v: var T)
+proc parseHook*[T](s: string, i: var int, v: var Option[T])
 
 template error(msg: string, i: int) =
   ## Shortcut to raise an exception.


### PR DESCRIPTION
`parseHook` for `Option[T]` is defined at `src/jsony.nim:494`,  
but it is missing from the forward declaration block at the top of the file.

When `parseObjectInner` line 389, binds `parseHook` for a field of type `Option[T]`, the Option overload is not yet in scope,
overload resolution then selects `parseHook*[T: object|ref object]` instead, because `Option` is an object.
The object hook starts with `eatChar(s, i, '{')`, so parsing any object with an `Option` field can fail with:
```nim
    Expected { but got 0 instead. At offset: N
```
Declaring the Option hook alongside the others fixes the binding.